### PR TITLE
Update Container configuration 2025.03 - 01

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,7 +11,7 @@ networks:
 services:
   orchestra:
     restart: unless-stopped
-    image: ezka77/xen-orchestra-ce:latest
+    image: ezka77/xen-orchestra-ce:5.170
     container_name: xo_server
     depends_on:
       - redis

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,6 +18,7 @@ services:
     labels:
       - traefik.enable=true
       - traefik.http.routers.xoa.tls=true
+      - traefik.http.routers.xoa.tls.certresolver=${CERTRESOLVER:-}
       - traefik.http.routers.xoa.rule=Host("${APPLICATION_FQDN}")
       - traefik.http.routers.xoa.service=xoa-service
       - traefik.http.services.xoa-service.loadbalancer.server.port=80

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,7 +17,9 @@ services:
       - redis
     labels:
       - traefik.enable=true
+      - traefik.http.routers.xoa.ruleSyntax=v3
       - traefik.http.routers.xoa.tls=true
+      - traefik.http.routers.xoa.entryPoints=https
       - traefik.http.routers.xoa.tls.certresolver=${CERTRESOLVER:-}
       - traefik.http.routers.xoa.rule=Host("${APPLICATION_FQDN}")
       - traefik.http.routers.xoa.service=xoa-service


### PR DESCRIPTION
- [Pin orchestra version to 5.170 to gain more stability in the lab](https://github.com/max-ra/cwa_xo/commit/90f5133ca6bb4f841b73be32b363c3a23b037056)
- [Enable option to activate acme with traefik](https://github.com/max-ra/cwa_xo/commit/88b9a2d6cea52dfc47d5d7b73295919f786ed614)
- Activate Traefik v3 rule syntax
- Only server connection form https entry points. Everything else will be
  redirected by Traefik itself anyway